### PR TITLE
Ignore answers other than TXT records at lookupTXT

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -51,8 +51,9 @@ func lookupTXT(d string) ([]string, error) {
 	}
 
 	for _, answ := range r.Answer {
-		t := answ.(*dns.TXT)
-		txt = append(txt, strings.Join(t.Txt, ""))
+		if t, ok := answ.(*dns.TXT); ok {
+			txt = append(txt, strings.Join(t.Txt, ""))
+		}
 	}
 	return txt, nil
 }


### PR DESCRIPTION
Hi.

I meet panic when checking for some domain.
the domain have one TXT record and one CHNAME record.
so i fixed with add type check.

```
panic: interface conversion: dns.RR is *dns.CNAME, not *dns.TXT

goroutine 1 [running]:
github.com/mileusna/spf.lookupTXT(0x6fe60c, 0x16, 0xc0000bdc18, 0x436fef, 0xc00002a000, 0xc0000bdc28, 0x4366fc)
	/home/nc30/go/1.13.4/pkg/mod/github.com/mileusna/spf@v0.9.2/resolver.go:54 +0x258
github.com/mileusna/spf.LookupSPF(0x6fe60c, 0x16, 0x42d851, 0x700530, 0xc0000bdcb8, 0xc0000bdca8)
	/home/nc30/go/1.13.4/pkg/mod/github.com/mileusna/spf@v0.9.2/resolver.go:20 +0x4d
github.com/mileusna/spf.(*check).checkHost(0xc0000bde40, 0xc00001a680, 0x10, 0x10, 0x6fe60c, 0x16, 0x6fe5e3, 0x3f, 0x6ef3f5, 0x1)
	/home/nc30/go/1.13.4/pkg/mod/github.com/mileusna/spf@v0.9.2/spf.go:66 +0x50
github.com/mileusna/spf.CheckHost(0xc00001a680, 0x10, 0x10, 0x6fe60c, 0x16, 0x6fe5e3, 0x3f, 0x0, 0x0, 0x8fb6a0, ...)
	/home/nc30/go/1.13.4/pkg/mod/github.com/mileusna/spf@v0.9.2/spf.go:60 +0x9c
gosmtp/src.SpfHeader(0x7464c0, 0xc000090f00, 0x6fe5e3, 0x3f, 0x1, 0x0)
	/home/nc30/wk/go/smtp/src/spf.go:37 +0xf7
main.main()
	/home/nc30/wk/go/smtp/test.go:26 +0x14f
exit status 2

```
